### PR TITLE
refactor: 레이아웃 포지션 조정 & 사이드바 현재 URL에 맞는 색상 표시

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -4,16 +4,16 @@ import NavigatorComp from './components/NavigatorComp.vue';
 </script>
 
 <template>
-  <div>
-    <div class="flex h-screen">
-      <nav class="p-4 bg-indigo-600 w-56">
+  <div class="h-screen w-screen">
+    <div class="flex h-full w-full">
+      <nav class="bg-indigo-600 w-52 fixed h-full">
         <NavigatorComp></NavigatorComp>
       </nav>
-      <div class="border grow">
-        <header>
-          <h1>Query Maker</h1>
+      <div class="flex flex-col h-full w-[calc(100%-13rem)] absolute left-52">
+        <header class="text-5xl mx-2 sticky top-0 bg-white">
+          <h1>QUERY MAKER</h1>
         </header>
-        <main>
+        <main class="m-2 h-full top-16">
           <router-view></router-view>
         </main>
       </div>

--- a/src/components/NavigatorComp.vue
+++ b/src/components/NavigatorComp.vue
@@ -1,6 +1,6 @@
 <template>
-    <div class="h-full text-xl text-slate-300 font-bold">
-      <ul class="h-full">
+    <div class="text-xl text-slate-300 font-bold">
+      <ul class="m-4">
         <li class="mb-2 flex flex-col">
           <div class="text-white text-2xl">
             DDL
@@ -33,7 +33,7 @@ import { ref } from 'vue';
 const route = useRoute()
 const router = useRouter()
 
-const routePath = ref()
+const routePath = ref("")
 
 const isDdlOver = ref(false)
 
@@ -42,13 +42,8 @@ router.afterEach(() => {
 })
 
 const isPath = (path) => {
-  return routePath.value == path
-}
-
-// events
-const handleDetailOver = () => {
-  isDdlOver.value = !isDdlOver.value;
-  console.log(isDdlOver.value)
+  const currentPath = routePath.value;
+  return currentPath.includes(path)
 }
 </script>
 <style lang="">

--- a/src/views/TableView.vue
+++ b/src/views/TableView.vue
@@ -25,7 +25,7 @@
             </div>
             
             <table class="table table-hover">
-                <thead class="text-center sticky-top">
+                <thead class="text-center">
                     <tr>
                         <th class="w-10" scope="col">name</th>
                         <th scope="col">type</th>


### PR DESCRIPTION
1. 사이드바와 메인 화면 그리고 query maker 헤더의 포지션을 설정하였다.

2. 사이드바를 클릭했을 때 URL에 맞는 selected 색상을 보여주었는데 DDL의 create를 클릭하고 /ddl/creation 화면에서 /ddl/creation/schema 또는 /ddl/creation/table 로 이동시 풀리는 문제가 발생하였다.

3. 2번의 문제점을 url비교가 아닌 매개변수로 넘겨준 URL이 현재 route 주소에 포함되어 있는지 체크하여 해결하였다.